### PR TITLE
feat: add frontend Dockerfile with non-root user

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,15 @@ RUN npm install
 # Copy all frontend files
 COPY . .
 
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Change ownership of the app directory to the non-root user
+RUN chown -R appuser:appgroup /app
+
+# Switch to the non-root user
+USER appuser
+
 # Expose Vite dev server port
 EXPOSE 5173
 


### PR DESCRIPTION
## Summary
- Add Dockerfile for the React/Vite frontend using node:20-alpine
- Run container as non-root user (appuser) for security
- Add .dockerignore to exclude node_modules, dist, and .env from the build context