### PR TITLE
fix: construct ECR image names via AWS CLI and escape dollar signs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,18 +177,9 @@ jobs:
           echo "[app_server]" > ansible/inventory.ini
           echo "app-vm ansible_host=${{ secrets.APP_HOST }} ansible_user=${{ secrets.APP_SSH_USER }} ansible_ssh_private_key_file=/home/runner/.ssh/deploy_key ansible_python_interpreter=/usr/bin/python3.8" >> ansible/inventory.ini
 
-      - name: Debug SSH Setup
+      - name: Verify SSH Connectivity
         run: |
-          echo "=== Inventory ==="
-          cat ansible/inventory.ini
-          echo "=== Key info ==="
-          ls -la /home/runner/.ssh/deploy_key
-          wc -l /home/runner/.ssh/deploy_key
-          ssh-keygen -lf /home/runner/.ssh/deploy_key || echo "Failed to read key fingerprint"
-          echo "=== Test bastion ==="
-          ssh -vvv -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 ${{ secrets.APP_SSH_USER }}@${{ secrets.BASTION_HOST }} "echo bastion_ok" 2>&1 || echo "BASTION FAILED"
-          echo "=== Test app via bastion ==="
-          ssh -vvv -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o ProxyCommand="ssh -W %h:%p -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.APP_SSH_USER }}@${{ secrets.BASTION_HOST }}" ${{ secrets.APP_SSH_USER }}@${{ secrets.APP_HOST }} "echo app_ok" 2>&1 || echo "APP FAILED"
+          ssh -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o ProxyCommand="ssh -W %h:%p -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.APP_SSH_USER }}@${{ secrets.BASTION_HOST }}" ${{ secrets.APP_SSH_USER }}@${{ secrets.APP_HOST }} "echo SSH connectivity verified"
 
       - name: Run Ansible Playbook
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,7 +191,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          ECR_REGISTRY=$(aws ecr describe-repositories --repository-names edurev-rwanda-backend --query 'repositories[0].repositoryUri' --output text | cut -d'/' -f1)
+          ECR_REGISTRY=$(aws ecr describe-repositories --region "$AWS_REGION" --repository-names edurev-rwanda-backend --query 'repositories[0].repositoryUri' --output text | cut -d'/' -f1)
           export BACKEND_IMAGE="$ECR_REGISTRY/edurev-rwanda-backend:${{ github.sha }}"
           export FRONTEND_IMAGE="$ECR_REGISTRY/edurev-rwanda-frontend:${{ github.sha }}"
           echo "BACKEND_IMAGE=$BACKEND_IMAGE"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -193,8 +193,6 @@ jobs:
       - name: Run Ansible Playbook
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
-          BACKEND_IMAGE: ${{ needs.build-and-push.outputs.backend_image }}
-          FRONTEND_IMAGE: ${{ needs.build-and-push.outputs.frontend_image }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           CORS_ORIGIN: ${{ secrets.CORS_ORIGIN }}
@@ -202,6 +200,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          ECR_REGISTRY=$(aws ecr describe-repositories --repository-names edurev-rwanda-backend --query 'repositories[0].repositoryUri' --output text | cut -d'/' -f1)
+          export BACKEND_IMAGE="$ECR_REGISTRY/edurev-rwanda-backend:${{ github.sha }}"
+          export FRONTEND_IMAGE="$ECR_REGISTRY/edurev-rwanda-frontend:${{ github.sha }}"
+          echo "BACKEND_IMAGE=$BACKEND_IMAGE"
+          echo "FRONTEND_IMAGE=$FRONTEND_IMAGE"
           ansible-playbook \
             -i ansible/inventory.ini \
             --ssh-common-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand='ssh -W %h:%p -i /home/runner/.ssh/deploy_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${{ secrets.APP_SSH_USER }}@${{ secrets.BASTION_HOST }}'" \

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -76,8 +76,8 @@
         content: |
           BACKEND_IMAGE={{ backend_image }}
           FRONTEND_IMAGE={{ frontend_image }}
-          DATABASE_URL={{ database_url }}
-          JWT_SECRET={{ jwt_secret }}
+          DATABASE_URL={{ database_url | replace('$', '$$') }}
+          JWT_SECRET={{ jwt_secret | replace('$', '$$') }}
           CORS_ORIGIN={{ cors_origin }}
 
     - name: Login to ECR


### PR DESCRIPTION
## Fixes

1. **Image names skipped by GitHub** — GitHub Actions was masking job outputs containing secret patterns (AWS account ID). Image names were empty in deploy job. Now constructs them via `aws ecr describe-repositories` in the run block.

2. **Dollar signs in DATABASE_URL and JWT_SECRET** — Docker-compose interprets `$` as variable references. Added Ansible `replace('$', '$$')` filter to escape them in the .env file.